### PR TITLE
Fix missing social rootUrl after clicking autofill

### DIFF
--- a/components/SignUpForm.tsx
+++ b/components/SignUpForm.tsx
@@ -130,7 +130,7 @@ function SignUpFormClient() {
       setSelectedSocials([
         ...knowClientUser.socials.map((social) => ({
           ...social,
-          value: social.url?.replace("https://" + social.rootUrl, ""),
+          value: social.url?.replace("https://", ""),
         })),
         ...(knowClientUser.atHnUrl
           ? [


### PR DESCRIPTION
## Summary
Fixes #6 
This PR addresses an issue where the `rootUrl` component of the social URL (e.g., `github.com/`) was being replaced with an empty string, resulting in missing link prefixes. 

The fix prevents the `rootUrl` from being included in the replacement operation, ensuring that the correct URL is maintained.

<img width="510" alt="image" src="https://github.com/user-attachments/assets/6baff250-76d3-47fa-af50-8ee2801dc6dc">

